### PR TITLE
feat: replace interactive json export with command line flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ All notable changes to this project will be documented in this file.
 - Functional listing of merged Pull Requests in the Pulse report.
 - Deduplication logic for PRs in the report to ensure each PR is only listed once.
 - New test file `tests/test_utils.py` for reporting logic verification.
-- Dynamic default filenames for JSON exports in the interactive prompt, incorporating the repository owner, name, and a timestamp.
+
+### Changed
+- Replaced the interactive JSON export prompt with an optional `--export` command-line flag. Running `--export` without an argument automatically generates a filename using the repository owner, name, and a timestamp.
 - Added default `owner` and `repo` parsing from local git remote if run within a cloned repository.
 
 ### Fixed

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -33,7 +33,7 @@ GITHUB_TOKEN=your_token_here
 | `--repo`  | Repository name | altinityknowledgebase |
 | `--days`  | Period in days | 30 |
 | `--token` | GitHub API Token | (from .env) |
-| `--export`| JSON filename | (prompted) |
+| `--export`| JSON filename (optional) | (AUTO generated) |
 
 ## Example CLI Usage
 
@@ -41,7 +41,10 @@ GITHUB_TOKEN=your_token_here
 # Weekly report for a specific repo
 python3 github_pulse_scraper.py --owner Altinity --repo clickhouse-operator --days 7
 
-# Export data directly to JSON
+# Export data to JSON with auto-generated filename
+python3 github_pulse_scraper.py --export
+
+# Export data directly to a specific JSON file
 python3 github_pulse_scraper.py --export clickhouse_pulse.json
 ```
 

--- a/github_pulse_scraper.py
+++ b/github_pulse_scraper.py
@@ -272,7 +272,7 @@ def main():
     parser.add_argument("--repo", default=default_repo, help=f"Repository name (default: {default_repo})")
     parser.add_argument("--days", type=int, default=30, help="Period in days (default: 30)")
     parser.add_argument("--token", help="GitHub Personal Access Token")
-    parser.add_argument("--export", help="Output JSON filename")
+    parser.add_argument("--export", nargs='?', const='AUTO', help="Export data to JSON (optionally provide a filename)")
     
     args = parser.parse_args()
 
@@ -285,18 +285,13 @@ def main():
             print("\n" + "=" * 80)
             print("Report complete!")
             
-            if args.export:
-                scraper.export_json(period_days=args.days, output_file=args.export)
-            else:
-                print("\n" + "=" * 80)
-                do_export = input("Export data to JSON? (y/n): ").strip().lower()
-                if do_export == 'y':
+            if args.export is not None:
+                if args.export == 'AUTO':
                     timestamp = datetime.now().strftime('%Y%m%d-%H%M%S')
-                    default_filename = f"{args.owner}-{args.repo}-{timestamp}.json"
-                    output_file = input(f"Output filename (default: {default_filename}): ").strip()
-                    if not output_file:
-                        output_file = default_filename
-                    scraper.export_json(period_days=args.days, output_file=output_file)
+                    output_file = f"{args.owner}-{args.repo}-{timestamp}.json"
+                else:
+                    output_file = args.export
+                scraper.export_json(period_days=args.days, output_file=output_file)
             break # Exit the loop on success
 
         except requests.exceptions.HTTPError as e:


### PR DESCRIPTION
Replaced the interactive prompt for exporting data to JSON with a flexible command-line flag.

- Modified the `--export` argument to accept an optional filename (e.g. `--export`).
- If `--export` is provided without a filename, it automatically generates a default name using the repository owner, name, and current timestamp.
- This ensures the scraper can run entirely non-interactively without getting stuck at the end waiting for user input.
- Updated `QUICKSTART.md` and `CHANGELOG.md` to reflect this change.